### PR TITLE
Updated stack.version to 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <stack.version>3.4.0-SNAPSHOT</stack.version>
+    <stack.version>3.4.2</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>
 


### PR DESCRIPTION
3.4.0.SNAPSHOT no longer exists and 3.4.2 is the latest release.